### PR TITLE
Msix support

### DIFF
--- a/kernel/input/xhci.c
+++ b/kernel/input/xhci.c
@@ -93,6 +93,26 @@ void make_ring_link(trb* ring, bool cycle){
     make_ring_link_control(ring, cycle);
 }
 
+
+uint8_t xhci_init_interrupts(uint64_t pci_addr){
+    bool msi_ok = pci_setup_msi(pci_addr, XHCI_IRQ);
+
+    if(msi_ok){
+        return 1;
+    }
+
+#define MSIX_IRQ_LENGTH 1
+
+    msix_irq_line irq_lines[MSIX_IRQ_LENGTH] = {(msix_irq_line){.addr_offset=0,.irq_num=XHCI_IRQ}};
+
+    bool msix_ok = pci_setup_msix(pci_addr, irq_lines, MSIX_IRQ_LENGTH);
+    if(msix_ok){
+        return 2;
+    }
+    
+    return 0;
+}
+
 bool xhci_init(xhci_device *xhci, uint64_t pci_addr) {
     kprintfv("[xHCI] init");
     if (!(read16(pci_addr + 0x06) & (1 << 4))){
@@ -100,14 +120,25 @@ bool xhci_init(xhci_device *xhci, uint64_t pci_addr) {
         return false;
     }
 
-    pci_setup_msi(pci_addr, XHCI_IRQ);
-
     if (!pci_setup_bar(pci_addr, 0, &xhci->mmio, &xhci->mmio_size)){
         kprintfv("[xHCI] BARs not set up");
         return false;
     }
 
     pci_register(xhci->mmio, xhci->mmio_size);
+
+    uint8_t interrupts_ok = xhci_init_interrupts(pci_addr);
+    switch(interrupts_ok){
+        case 0:
+            kprintf_raw("[xHCI] Failed to setup interrupts\n");
+            return false;
+        case 2:
+            kprintf_raw("[xHCI] Interrupts setup with MSI-X");
+            break;
+        default:
+            kprintf_raw("[xHCI] Interrupts setup with MSI");
+            break;
+    }
 
     pci_enable_device(pci_addr);
 

--- a/kernel/pci.h
+++ b/kernel/pci.h
@@ -23,7 +23,13 @@ void pci_register(uint64_t mmio_addr, uint64_t mmio_size);
 void pci_enable_verbose();
 
 bool pci_setup_msi(uint64_t pci_addr, uint8_t irq_vector);
-bool pci_setup_msix(uint64_t pci_addr, uint8_t irq_line);
+
+typedef struct {
+    uint32_t addr_offset;
+    uint8_t irq_num;
+} msix_irq_line;
+
+bool pci_setup_msix(uint64_t pci_addr, msix_irq_line* irq_lines, uint8_t line_size);
 
 #ifdef __cplusplus
 }

--- a/run
+++ b/run
@@ -7,6 +7,14 @@ if [ "$1" = "debug" ]; then
   ARGS="-monitor unix:/tmp/qemu-monitor-socket,server,nowait -s -S"
 fi
 
+MSI_CAPABILITIES=""
+
+XHCI_CAPABILITIES="$(qemu-system-aarch64 -device qemu-xhci,help)"
+
+if echo "$XHCI_CAPABILITIES" | grep -q "msi "; then
+  MSI_CAPABILITIES="msi=on,msix=off,"
+fi
+
 qemu-system-aarch64 \
 -M virt \
 -cpu cortex-a72 \
@@ -17,7 +25,7 @@ qemu-system-aarch64 \
 -serial mon:stdio \
 -drive file=disk.img,if=none,format=raw,id=hd0 \
 -device virtio-blk-pci,drive=hd0 \
--device qemu-xhci,msi=on,msix=off,id=usb \
+-device qemu-xhci,${MSI_CAPABILITIES}id=usb \
 -device usb-kbd,bus=usb.0 \
 -d guest_errors \
 $ARGS


### PR DESCRIPTION
Hi me again, I noticed, that my local qemu doesn't support the device options `msi=on,msix=off` for the `qemu-xhci` device. 

So I removed them, but than my keyboard didn't work. So there was this issues in your existing code:

You didn't check the return code of `pci_setup_msi`, if that returns false, no interrupts are enabled and the keyboard doesn't work,

So I added a function, that tries to initialize MSI and if that fails it tries to use MSI-X. While doing that I found some more bugs introduced by this behavior. If you don't call `pci_setup_bar` before calling `pci_setup_msix` the table pointer is null, which didn't throw an error before, but is one, as this should point to valid memory. So I fixed the order, and also added the assertion for the table to never be null.

I also improved a few things in the pci code, that I found. So I replaced hard coded values with named constants (e.g. `#define PCI_CAPABILITY_MSI 0x05` )

I also added the capability of multiple interrupts to the MSI-X function, as msix support that.

I also added a small detection of the qemu device features, you can get them with `qemu-system-aarch64 -device qemu-xhci,help` so that if your qemu (as it may differ from distro to distro or if you compiled it yourself) options are supported.


It is a little more than just fixing the bug and making msix work but i debugged it for quite some time, as the issue was not that easy to find, so I added some more checks and improvements and I just didn't wanted to remove them just now.

So if you don't want to accept this exact code just let me know :)

At least now the keyboard works with my qemu on my machine :)