### PR TITLE
Fixing Linux Issues

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -3,7 +3,7 @@ CC = $(ARCH)-gcc
 LD = $(ARCH)-ld
 OBJCOPY = $(ARCH)-objcopy
 
-CFLAGS = -g -O0 -nostdlib -ffreestanding -fno-exceptions -fno-unwind-tables -fno-asynchronous-unwind-tables -Wall -Wextra -mcpu=cortex-a72 -I. -I../shared -I../user
+CFLAGS = -g -O0 -std=c17 -nostdlib -ffreestanding -fno-exceptions -fno-unwind-tables -fno-asynchronous-unwind-tables -Wall -Wextra -mcpu=cortex-a72 -I. -I../shared -I../user
 LDFLAGS = -T $(shell ls *.ld)
 
 C_SRC = $(shell find . -name '*.c')

--- a/kernel/exceptions/exception_handler.c
+++ b/kernel/exceptions/exception_handler.c
@@ -8,6 +8,10 @@
 #include "theme/theme.h"
 #include "std/string.h"
 
+#ifndef asm
+#define asm __asm__
+#endif
+
 static bool panic_triggered = false;
 
 void set_exception_vectors(){

--- a/kernel/exceptions/irq.c
+++ b/kernel/exceptions/irq.c
@@ -8,6 +8,10 @@
 #include "console/serial/uart.h"
 #include "networking/network.h"
 
+#ifndef asm
+#define asm __asm__
+#endif
+
 #define IRQ_TIMER 30
 #define SLEEP_TIMER 27
 

--- a/kernel/exceptions/timer.c
+++ b/kernel/exceptions/timer.c
@@ -1,5 +1,9 @@
 #include "timer.h"
 
+#ifndef asm
+#define asm __asm__
+#endif
+
 static uint64_t _msecs;
 
 void timer_reset() {

--- a/kernel/fw/fw_cfg.c
+++ b/kernel/fw/fw_cfg.c
@@ -3,6 +3,10 @@
 #include "memory/memory_access.h"
 #include "kstring.h"
 
+#ifndef asm
+#define asm __asm__
+#endif
+
 #define FW_CFG_DATA  0x09020000
 #define FW_CFG_CTL   (FW_CFG_DATA + 0x8)
 #define FW_CFG_DMA   (FW_CFG_DATA + 0x10)
@@ -13,6 +17,7 @@
 #define FW_CFG_DMA_ERROR 0x1
 
 #define FW_LIST_DIRECTORY 0x19
+
 
 static bool checked = false;
 

--- a/kernel/memory/mmu.c
+++ b/kernel/memory/mmu.c
@@ -8,6 +8,10 @@
 #include "filesystem/disk.h"
 #include "memory/page_allocator.h"
 
+#ifndef asm
+#define asm __asm__
+#endif
+
 #define MAIR_DEVICE_nGnRnE 0b00000000
 #define MAIR_NORMAL_NOCACHE 0b01000100
 #define MAIR_IDX_DEVICE 0

--- a/kernel/process/syscall.c
+++ b/kernel/process/syscall.c
@@ -14,6 +14,10 @@
 #include "exceptions/timer.h"
 #include "networking/network.h"
 
+#ifndef asm
+#define asm __asm__
+#endif
+
 void sync_el0_handler_c(){
     save_context_registers();
     save_return_address_interrupt();

--- a/kernel/virtio/virtio_pci.c
+++ b/kernel/virtio/virtio_pci.c
@@ -4,6 +4,10 @@
 #include "memory/page_allocator.h"
 #include "virtio_pci.h"
 
+#ifndef asm
+#define asm __asm__
+#endif
+
 #define VIRTIO_STATUS_RESET         0x0
 #define VIRTIO_STATUS_ACKNOWLEDGE   0x1
 #define VIRTIO_STATUS_DRIVER        0x2

--- a/run
+++ b/run
@@ -1,4 +1,4 @@
-#/!bin/sh
+#!/bin/sh
 
 echo "Running emulator"
 
@@ -15,19 +15,33 @@ if echo "$XHCI_CAPABILITIES" | grep -q "msi "; then
   MSI_CAPABILITIES="msi=on,msix=off,"
 fi
 
+OS_TYPE="$(uname)"
+
+if [[ "$OS_TYPE" == "Darwin" ]]; then
+    NETARG="vmnet-bridged,id=net0,ifname=en0"
+
+elif [[ "$OS_TYPE" == "Linux" ]]; then
+    NETARG="user,id=net0"
+
+else
+    echo "Unknown OS: $OS_TYPE" >&2
+    exit 1
+fi
+
+
 qemu-system-aarch64 \
--M virt \
--cpu cortex-a72 \
--m 512M \
--kernel kernel.elf \
--device virtio-gpu-pci \
--display sdl \
--netdev vmnet-bridged,id=net0,ifname=en0 \
--device virtio-net-pci,netdev=net0 \
--serial mon:stdio \
--drive file=disk.img,if=none,format=raw,id=hd0 \
--device virtio-blk-pci,drive=hd0 \
--device qemu-xhci,${MSI_CAPABILITIES}id=usb \
--device usb-kbd,bus=usb.0 \
--d guest_errors \
-$ARGS
+  -M virt \
+  -cpu cortex-a72 \
+  -m 512M \
+  -kernel kernel.elf \
+  -device virtio-gpu-pci \
+  -display sdl \
+  -netdev ${NETARG} \
+  -device virtio-net-pci,netdev=net0 \
+  -serial mon:stdio \
+  -drive file=disk.img,if=none,format=raw,id=hd0 \
+  -device virtio-blk-pci,drive=hd0 \
+  -device qemu-xhci,${MSI_CAPABILITIES}id=usb \
+  -device usb-kbd,bus=usb.0 \
+  -d guest_errors \
+  $ARGS

--- a/shared/Makefile
+++ b/shared/Makefile
@@ -3,7 +3,7 @@ CC = $(ARCH)-gcc
 AR = $(ARCH)-ar
 OBJCOPY = $(ARCH)-objcopy
 
-CFLAGS = -g -O0 -nostdlib -nolibc -ffreestanding -fno-exceptions -fno-unwind-tables -fno-asynchronous-unwind-tables -Wall -Wextra -mcpu=cortex-a72 -I. -I../kernel -Wno-unused-parameter
+CFLAGS = -g -O0 -std=c17 -nostdlib -nolibc -ffreestanding -fno-exceptions -fno-unwind-tables -fno-asynchronous-unwind-tables -Wall -Wextra -mcpu=cortex-a72 -I. -I../kernel -Wno-unused-parameter
 
 C_SRC = $(shell find . -name '*.c')
 CPP_SRC = $(shell find . -name '*.cpp')

--- a/user/Makefile
+++ b/user/Makefile
@@ -3,7 +3,7 @@ CC = $(ARCH)-gcc
 LD = $(ARCH)-ld
 OBJCOPY = $(ARCH)-objcopy
 
-CFLAGS = -g -O0 -nostdlib -ffreestanding -Wall -Wextra -mcpu=cortex-a72 -I. -I../shared -Wno-unused-parameter
+CFLAGS = -g -O0 -std=c17 -nostdlib -ffreestanding -Wall -Wextra -mcpu=cortex-a72 -I. -I../shared -Wno-unused-parameter
 LDFLAGS = -T $(shell ls *.ld)
 
 C_SRC = $(shell find . -name '*.c')


### PR DESCRIPTION
I encountered a few issues while compiling and running on Linux that I have fixed. The bool keyword is reserved as of C23, so I have adding in the CFLAGS to use C17 (the standard before C23), vmnet-bridged is a MacOS only feature and needs to be changed for Linux, and the asm keyword isn't defined by some compilers, but __asm__ is there is a check for that in the files that use the asm keyword