### PR TITLE
Use GCC dependency generation in Makefiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ dump
 .cache/*
 compile_commands.json
 .clangd
+*.d

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -9,11 +9,13 @@ endif
 LDFLAGS := $(LDFLAGS_BASE) -T $(shell ls *.ld) --defsym=LOAD_ADDR=$(LOAD_ADDR)
 
 CLEAN_OBJS := $(shell find . -name '*.o')
+CLEAN_DEPS := $(shell find . -name '*.d')
 C_SRC   := $(shell find . -name '*.c')
 ASM_SRC := $(shell find . -name '*.S')
 CPP_SRC := $(shell find . -name '*.cpp')
 OBJ     := $(C_SRC:.c=.o) $(ASM_SRC:.S=.o) $(CPP_SRC:.cpp=.o)
 OBJL    := $(filter-out ./boot.o,$(OBJ))
+DEP     := $(C_SRC:.c=.d) $(ASM_SRC:.S=.d) $(CPP_SRC:.cpp=.d)
 
 ELF     := ../kernel.elf
 TARGET  := ../kernel.img
@@ -25,11 +27,13 @@ $(TARGET): ../shared/libshared.a $(OBJ)
 	$(OBJCOPY) -O binary $(ELF) $@
 
 %.o: %.S
-	$(CC) $(CFLAGS) -c $< -o $@
+	$(CC) $(CFLAGS) -c -MMD -MP $< -o $@
 %.o: %.c
-	$(CC) $(CFLAGS) $(CONLY_FLAGS_BASE) -c $< -o $@
+	$(CC) $(CFLAGS) $(CONLY_FLAGS_BASE) -c -MMD -MP $< -o $@
 %.o: %.cpp
-	$(CC) $(CFLAGS) -fno-rtti -c $< -o $@
+	$(CC) $(CFLAGS) -fno-rtti -c -MMD -MP $< -o $@
 
 clean:
-	rm -f $(CLEAN_OBJS) $(ELF) $(TARGET)
+	rm -f $(CLEAN_OBJS) $(CLEAN_DEPS) $(ELF) $(TARGET)
+
+-include $(DEP)

--- a/shared/Makefile
+++ b/shared/Makefile
@@ -2,10 +2,12 @@
 CFLAGS  := $(CFLAGS_BASE) -I. -I../kernel -Wno-unused-parameter
 
 CLEAN_OBJS := $(shell find . -name '*.o')
+CLEAN_DEPS := $(shell find . -name '*.d')
 C_SRC   := $(shell find . -name '*.c')
 CPP_SRC := $(shell find . -name '*.cpp')
 ASM_SRC := $(shell find . -name '*.S')
 OBJ     := $(C_SRC:.c=.o) $(ASM_SRC:.S=.o) $(CPP_SRC:.cpp=.o)
+DEP     := $(C_SRC:.c=.d) $(ASM_SRC:.S=.d) $(CPP_SRC:.cpp=.d)
 
 TARGET  := libshared.a
 
@@ -17,13 +19,15 @@ $(TARGET): $(OBJ)
 	$(AR) rcs $@ $^
 
 %.o: %.S
-	$(CC) $(CFLAGS) -c $< -o $@
+	$(CC) $(CFLAGS) -c -MMD -MP $< -o $@
 
 %.o: %.c
-	$(CC) $(CFLAGS) $(CONLY_FLAGS_BASE) -c $< -o $@
+	$(CC) $(CFLAGS) $(CONLY_FLAGS_BASE) -c -MMD -MP $< -o $@
 
 %.o: %.cpp
-	$(CC) $(CFLAGS) -fno-rtti -c $< -o $@
+	$(CC) $(CFLAGS) -fno-rtti -c -MMD -MP $< -o $@
 
 clean:
-	rm -f $(CLEAN_OBJS) $(TARGET)
+	rm -f $(CLEAN_OBJS) $(CLEAN_DEPS) $(TARGET)
+
+-include $(DEP)

--- a/user/Makefile
+++ b/user/Makefile
@@ -3,9 +3,11 @@ CFLAGS  := $(CFLAGS_BASE) -I. -I../shared -Wno-unused-parameter
 LDFLAGS := -T $(shell ls *.ld)
 
 CLEAN_OBJS := $(shell find . -name '*.o')
+CLEAN_DEPS := $(shell find . -name '*.d')
 C_SRC   := $(shell find . -name '*.c')
 CPP_SRC := $(shell find . -name '*.cpp')
 OBJ     := $(C_SRC:.c=.o) $(CPP_SRC:.cpp=.o)
+DEP     := $(C_SRC:.c=.d) $(CPP_SRC:.cpp=.d)
 
 NAME     := $(notdir $(CURDIR))
 ELF      := $(NAME).elf
@@ -21,13 +23,15 @@ $(LOCATION)$(TARGET): $(OBJ)
 	$(OBJCOPY) -O binary $(LOCATION)$(ELF) $@
 
 %.o: %.S
-	$(CC) $(CFLAGS) -c $< -o $@
+	$(CC) $(CFLAGS) -c -MMD -MP $< -o $@
 
 %.o: %.c
-	$(CC) $(CFLAGS) $(CONLY_FLAGS_BASE) -c $< -o $@
+	$(CC) $(CFLAGS) $(CONLY_FLAGS_BASE) -c -MMD -MP $< -o $@
 
 %.o: %.cpp
-	$(CC) $(CFLAGS) -fno-rtti -c $< -o $@
+	$(CC) $(CFLAGS) -fno-rtti -c -MMD -MP $< -o $@
 
 clean:
-	rm -f $(CLEAN_OBJS) $(TARGET)
+	rm -f $(CLEAN_OBJS) $(CLEAN_DEPS) $(TARGET)
+
+-include $(DEP)


### PR DESCRIPTION
This causes source files which depend on headers to be rebuilt when the header changes. `-MMD` generates the dependencies in `*.d` files, excluding system headers. `-MP` adds fake rules for headers to the dependencies file so build doesn't break if a header is removed. Update `.gitignore` to ignore new `*.d` files.