### PR TITLE
Make cleanups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,41 +1,4 @@
-ARCH       ?= aarch64-none-elf
-CC         := $(ARCH)-gcc
-CXX        := $(ARCH)-g++
-LD         := $(ARCH)-ld
-AR         := $(ARCH)-ar
-OBJCOPY    := $(ARCH)-objcopy
-
-COMMON_FLAGS  ?= -ffreestanding -nostdlib -fno-exceptions -fno-unwind-tables \
-                 -fno-asynchronous-unwind-tables -g -O0 -Wall -Wextra \
-                 -Wno-unused-parameter -Wno-address-of-packed-member \
-                 -mcpu=cortex-a72
-
-CFLAGS_BASE   ?= $(COMMON_FLAGS) -std=c17
-CXXFLAGS_BASE ?= $(COMMON_FLAGS) -fno-rtti
-LDFLAGS_BASE  ?=
-
-LOAD_ADDR      ?= 0x41000000
-XHCI_CTX_SIZE  ?= 32
-QEMU           ?= true
-MODE           ?= virt
-
-ifeq ($(V), 1)
-  VAR  = $(AR)
-  VAS  = $(CC)
-  VCC  = $(CC)
-  VCXX = $(CXX)
-  VLD  = $(LD)
-else
-  VAR  = @echo "  [AR]   $@" && $(AR)
-  VAS  = @echo "  [AS]   $@" && $(CC)
-  VCC  = @echo "  [CC]   $@" && $(CC)
-  VCXX = @echo "  [CXX]  $@" && $(CXX)
-  VLD  = @echo "  [LD]   $@" && $(LD)
-endif
-
-export AR AS CC CXX LD OBJCOPY
-export VAR VAS VCC VCXX VLD
-export ARCH COMMON_FLAGS CFLAGS_BASE CXXFLAGS_BASE LDFLAGS_BASE LOAD_ADDR XHCI_CTX_SIZE QEMU
+include common.mk
 
 OS      := $(shell uname)
 FS_DIRS := fs/redos/user

--- a/common.mk
+++ b/common.mk
@@ -1,0 +1,34 @@
+ARCH       ?= aarch64-none-elf
+CC         := $(ARCH)-gcc
+CXX        := $(ARCH)-g++
+LD         := $(ARCH)-ld
+AR         := $(ARCH)-ar
+OBJCOPY    := $(ARCH)-objcopy
+
+COMMON_FLAGS  ?= -ffreestanding -nostdlib -fno-exceptions -fno-unwind-tables \
+                 -fno-asynchronous-unwind-tables -g -O0 -Wall -Wextra \
+                 -Wno-unused-parameter -Wno-address-of-packed-member \
+                 -mcpu=cortex-a72
+
+CFLAGS_BASE   ?= $(COMMON_FLAGS) -std=c17
+CXXFLAGS_BASE ?= $(COMMON_FLAGS) -fno-rtti
+LDFLAGS_BASE  ?=
+
+LOAD_ADDR      ?= 0x41000000
+XHCI_CTX_SIZE  ?= 32
+QEMU           ?= true
+MODE           ?= virt
+
+ifeq ($(V), 1)
+  VAR  = $(AR)
+  VAS  = $(CC)
+  VCC  = $(CC)
+  VCXX = $(CXX)
+  VLD  = $(LD)
+else
+  VAR  = @echo "  [AR]   $@" && $(AR)
+  VAS  = @echo "  [AS]   $@" && $(CC)
+  VCC  = @echo "  [CC]   $@" && $(CC)
+  VCXX = @echo "  [CXX]  $@" && $(CXX)
+  VLD  = @echo "  [LD]   $@" && $(LD)
+endif

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -1,6 +1,8 @@
 #kernel
 # toolchain (inherited from top-level)
 
+include ../common.mk
+
 CPPFLAGS := -I. -I../shared -I../user -DXHCI_CTX_SIZE=$(XHCI_CTX_SIZE)
 
 ifeq ($(QEMU),true)

--- a/shared/Makefile
+++ b/shared/Makefile
@@ -1,4 +1,7 @@
 #shared
+
+include ../common.mk
+
 CPPFLAGS := -I. -I../kernel
 CFLAGS   := $(CFLAGS_BASE) $(CPPFLAGS)
 CXXFLAGS := $(CXXFLAGS_BASE) $(CPPFLAGS)

--- a/user/Makefile
+++ b/user/Makefile
@@ -1,4 +1,7 @@
 #user
+
+include ../common.mk
+
 CPPFLAGS := -I. -I../shared
 CFLAGS   := $(CFLAGS_BASE) $(CPPFLAGS)
 CXXFLAGS := $(CXXFLAGS_BASE) $(CPPFLAGS)


### PR DESCRIPTION
Various cleanups and improvements to Make build system.

Most notably extracting common variables into `common.mk` file and including that in the other Makefiles and enabling "silent" builds (by default) to make it easier to grok the build system output. Silent build can be disabled by passing V=1 argument to Make like `make V=1`.

Feel free to ignore or cherry-pick.

It's based on my previous PR branch so includes that commit, hopefully it can merge cleanly. I can probably fix it if it gives any grief.