### PR TITLE
Cleanup warnings optimized

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ dump
 .cache/*
 compile_commands.json
 .clangd
+*.d

--- a/Makefile
+++ b/Makefile
@@ -1,41 +1,4 @@
-ARCH       ?= aarch64-none-elf
-CC         := $(ARCH)-gcc
-CXX        := $(ARCH)-g++
-LD         := $(ARCH)-ld
-AR         := $(ARCH)-ar
-OBJCOPY    := $(ARCH)-objcopy
-
-COMMON_FLAGS  ?= -ffreestanding -nostdlib -fno-exceptions -fno-unwind-tables \
-                 -fno-asynchronous-unwind-tables -g -O0 -Wall -Wextra \
-                 -Wno-unused-parameter -Wno-address-of-packed-member \
-                 -mcpu=cortex-a72
-
-CFLAGS_BASE   ?= $(COMMON_FLAGS) -std=c17
-CXXFLAGS_BASE ?= $(COMMON_FLAGS) -fno-rtti
-LDFLAGS_BASE  ?=
-
-LOAD_ADDR      ?= 0x41000000
-XHCI_CTX_SIZE  ?= 32
-QEMU           ?= true
-MODE           ?= virt
-
-ifeq ($(V), 1)
-  VAR  = $(AR)
-  VAS  = $(CC)
-  VCC  = $(CC)
-  VCXX = $(CXX)
-  VLD  = $(LD)
-else
-  VAR  = @echo "  [AR]   $@" && $(AR)
-  VAS  = @echo "  [AS]   $@" && $(CC)
-  VCC  = @echo "  [CC]   $@" && $(CC)
-  VCXX = @echo "  [CXX]  $@" && $(CXX)
-  VLD  = @echo "  [LD]   $@" && $(LD)
-endif
-
-export AR AS CC CXX LD OBJCOPY
-export VAR VAS VCC VCXX VLD
-export ARCH COMMON_FLAGS CFLAGS_BASE CXXFLAGS_BASE LDFLAGS_BASE LOAD_ADDR XHCI_CTX_SIZE QEMU
+include common.mk
 
 OS      := $(shell uname)
 FS_DIRS := fs/redos/user

--- a/Makefile
+++ b/Makefile
@@ -62,9 +62,9 @@ kernel:
 	$(MAKE) -C kernel LOAD_ADDR=$(LOAD_ADDR) XHCI_CTX_SIZE=$(XHCI_CTX_SIZE) QEMU=$(QEMU)
 
 clean:
-	$(MAKE) -C shared clean
-	$(MAKE) -C user   clean
-	$(MAKE) -C kernel clean
+	$(MAKE) -C shared $@
+	$(MAKE) -C user   $@
+	$(MAKE) -C kernel $@
 	@echo "removing fs dirs"
 	$(RM) -r $(FS_DIRS)
 	@echo "removing images"

--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,25 @@
 ARCH       ?= aarch64-none-elf
 CC         := $(ARCH)-gcc
+CXX        := $(ARCH)-g++
 LD         := $(ARCH)-ld
 AR         := $(ARCH)-ar
 OBJCOPY    := $(ARCH)-objcopy
 
-CFLAGS_BASE  ?= -g -O0 -nostdlib -ffreestanding \
-                -fno-exceptions -fno-unwind-tables -fno-asynchronous-unwind-tables \
-                -Wall -Wextra -Wno-unused-parameter -Wno-address-of-packed-member -mcpu=cortex-a72
-CONLY_FLAGS_BASE ?= -std=c17
-LDFLAGS_BASE ?=
+COMMON_FLAGS  ?= -ffreestanding -nostdlib -fno-exceptions -fno-unwind-tables \
+                 -fno-asynchronous-unwind-tables -g -O0 -Wall -Wextra \
+                 -Wno-unused-parameter -Wno-address-of-packed-member \
+                 -mcpu=cortex-a72
+
+CFLAGS_BASE   ?= $(COMMON_FLAGS) -std=c17
+CXXFLAGS_BASE ?= $(COMMON_FLAGS) -fno-rtti
+LDFLAGS_BASE  ?=
 
 LOAD_ADDR      ?= 0x41000000
 XHCI_CTX_SIZE  ?= 32
 QEMU           ?= true
 MODE           ?= virt
 
-export ARCH CC LD AR OBJCOPY CFLAGS_BASE CONLY_FLAGS_BASE LDFLAGS_BASE LOAD_ADDR XHCI_CTX_SIZE QEMU
+export ARCH CC CXX LD AR OBJCOPY COMMON_FLAGS CFLAGS_BASE CXXFLAGS_BASE LDFLAGS_BASE LOAD_ADDR XHCI_CTX_SIZE QEMU
 
 OS      := $(shell uname)
 FS_DIRS := fs/redos/user

--- a/Makefile
+++ b/Makefile
@@ -46,9 +46,9 @@ clean:
 	$(MAKE) -C user   clean
 	$(MAKE) -C kernel clean
 	@echo "removing fs dirs"
-	rm -rf $(FS_DIRS)
+	$(RM) -r $(FS_DIRS)
 	@echo "removing images"
-	rm -f kernel.img kernel.elf disk.img dump
+	$(RM) kernel.img kernel.elf disk.img dump
 
 raspi:
 	$(MAKE) LOAD_ADDR=0x80000 XHCI_CTX_SIZE=64 QEMU=true all

--- a/Makefile
+++ b/Makefile
@@ -63,11 +63,11 @@ run:
 debug:
 	$(MAKE) $(MODE)
 	./rundebug MODE=$(MODE) $(ARGS)
-  
+
 dump:
 	$(OBJCOPY) -O binary kernel.elf kernel.img
-	aarch64-none-elf-objdump -D kernel.elf > dump
-  
+	$(ARCH)-objdump -D kernel.elf > dump
+
 install:
 	$(MAKE) clean
 	$(MAKE) LOAD_ADDR=0x80000 XHCI_CTX_SIZE=64 QEMU=false all

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,23 @@ XHCI_CTX_SIZE  ?= 32
 QEMU           ?= true
 MODE           ?= virt
 
-export ARCH CC CXX LD AR OBJCOPY COMMON_FLAGS CFLAGS_BASE CXXFLAGS_BASE LDFLAGS_BASE LOAD_ADDR XHCI_CTX_SIZE QEMU
+ifeq ($(V), 1)
+  VAR  = $(AR)
+  VAS  = $(CC)
+  VCC  = $(CC)
+  VCXX = $(CXX)
+  VLD  = $(LD)
+else
+  VAR  = @echo "  [AR]   $@" && $(AR)
+  VAS  = @echo "  [AS]   $@" && $(CC)
+  VCC  = @echo "  [CC]   $@" && $(CC)
+  VCXX = @echo "  [CXX]  $@" && $(CXX)
+  VLD  = @echo "  [LD]   $@" && $(LD)
+endif
+
+export AR AS CC CXX LD OBJCOPY
+export VAR VAS VCC VCXX VLD
+export ARCH COMMON_FLAGS CFLAGS_BASE CXXFLAGS_BASE LDFLAGS_BASE LOAD_ADDR XHCI_CTX_SIZE QEMU
 
 OS      := $(shell uname)
 FS_DIRS := fs/redos/user
@@ -93,4 +109,6 @@ help:
   make debug        build and run with debugger\n\
   make dump         disassemble kernel.elf\n\
   make install      create raspi kernel and mount it on a bootable partition\n\
-  make prepare-fs   create directories for the filesystem\n\n"
+  make prepare-fs   create directories for the filesystem\n\n"\
+  \n\
+  Use 'make V=1' for verbose build output.

--- a/common.mk
+++ b/common.mk
@@ -1,0 +1,34 @@
+ARCH       ?= aarch64-none-elf
+CC         := $(ARCH)-gcc
+CXX        := $(ARCH)-g++
+LD         := $(ARCH)-ld
+AR         := $(ARCH)-ar
+OBJCOPY    := $(ARCH)-objcopy
+
+COMMON_FLAGS  ?= -ffreestanding -nostdlib -fno-exceptions -fno-unwind-tables \
+                 -fno-asynchronous-unwind-tables -g -O0 -Wall -Wextra \
+                 -Wno-unused-parameter -Wno-address-of-packed-member \
+                 -mcpu=cortex-a72
+
+CFLAGS_BASE   ?= $(COMMON_FLAGS) -std=c17
+CXXFLAGS_BASE ?= $(COMMON_FLAGS) -fno-rtti
+LDFLAGS_BASE  ?=
+
+LOAD_ADDR      ?= 0x41000000
+XHCI_CTX_SIZE  ?= 32
+QEMU           ?= true
+MODE           ?= virt
+
+ifeq ($(V), 1)
+  VAR  = $(AR)
+  VAS  = $(CC)
+  VCC  = $(CC)
+  VCXX = $(CXX)
+  VLD  = $(LD)
+else
+  VAR  = @echo "  [AR]   $@" && $(AR)
+  VAS  = @echo "  [AS]   $@" && $(CC)
+  VCC  = @echo "  [CC]   $@" && $(CC)
+  VCXX = @echo "  [CXX]  $@" && $(CXX)
+  VLD  = @echo "  [LD]   $@" && $(LD)
+endif

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -1,6 +1,8 @@
 #kernel
 # toolchain (inherited from top-level)
 
+include ../common.mk
+
 CPPFLAGS := -I. -I../shared -I../user -DXHCI_CTX_SIZE=$(XHCI_CTX_SIZE)
 
 ifeq ($(QEMU),true)

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -26,17 +26,17 @@ TARGET  := ../kernel.img
 all: $(TARGET)
 
 $(TARGET): ../shared/libshared.a $(OBJ)
-	$(LD) $(LDFLAGS) -o $(ELF) $(OBJL) ../shared/libshared.a
+	$(VLD) $(LDFLAGS) -o $(ELF) $(OBJL) ../shared/libshared.a
 	$(OBJCOPY) -O binary $(ELF) $@
 
 %.o: %.S
-	$(CC) $(CFLAGS) -c -MMD -MP $< -o $@
+	$(VAS) $(CFLAGS) -c $< -o $@
 
 %.o: %.c
-	$(CC) $(CFLAGS) -c -MMD -MP $< -o $@
+	$(VCC) $(CFLAGS) -c -MMD -MP $< -o $@
 
 %.o: %.cpp
-	$(CXX) $(CXXFLAGS) -c -MMD -MP $< -o $@
+	$(VCXX) $(CXXFLAGS) -c -MMD -MP $< -o $@
 
 clean:
 	$(RM) $(CLEAN_OBJS) $(CLEAN_DEPS) $(ELF) $(TARGET)

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -9,11 +9,13 @@ endif
 LDFLAGS := $(LDFLAGS_BASE) -T $(shell ls *.ld) --defsym=LOAD_ADDR=$(LOAD_ADDR)
 
 CLEAN_OBJS := $(shell find . -name '*.o')
+CLEAN_DEPS := $(shell find . -name '*.d')
 C_SRC   := $(shell find . -name '*.c')
 ASM_SRC := $(shell find . -name '*.S')
 CPP_SRC := $(shell find . -name '*.cpp')
 OBJ     := $(C_SRC:.c=.o) $(ASM_SRC:.S=.o) $(CPP_SRC:.cpp=.o)
 OBJL    := $(filter-out ./boot.o,$(OBJ))
+DEP     := $(C_SRC:.c=.d) $(ASM_SRC:.S=.d) $(CPP_SRC:.cpp=.d)
 
 ELF     := ../kernel.elf
 TARGET  := ../kernel.img
@@ -25,11 +27,13 @@ $(TARGET): ../shared/libshared.a $(OBJ)
 	$(OBJCOPY) -O binary $(ELF) $@
 
 %.o: %.S
-	$(CC) $(CFLAGS) -c $< -o $@
+	$(CC) $(CFLAGS) -c -MMD -MP $< -o $@
 %.o: %.c
-	$(CC) $(CFLAGS) $(CONLY_FLAGS_BASE) -c $< -o $@
+	$(CC) $(CFLAGS) $(CONLY_FLAGS_BASE) -c -MMD -MP $< -o $@
 %.o: %.cpp
-	$(CC) $(CFLAGS) -fno-rtti -c $< -o $@
+	$(CC) $(CFLAGS) -fno-rtti -c -MMD -MP $< -o $@
 
 clean:
-	rm -f $(CLEAN_OBJS) $(ELF) $(TARGET)
+	rm -f $(CLEAN_OBJS) $(CLEAN_DEPS) $(ELF) $(TARGET)
+
+-include $(DEP)

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -34,6 +34,6 @@ $(TARGET): ../shared/libshared.a $(OBJ)
 	$(CC) $(CFLAGS) -fno-rtti -c -MMD -MP $< -o $@
 
 clean:
-	rm -f $(CLEAN_OBJS) $(CLEAN_DEPS) $(ELF) $(TARGET)
+	$(RM) $(CLEAN_OBJS) $(CLEAN_DEPS) $(ELF) $(TARGET)
 
 -include $(DEP)

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -1,12 +1,15 @@
 #kernel
 # toolchain (inherited from top-level)
 
-CFLAGS := $(CFLAGS_BASE) -I. -I../shared -I../user -DXHCI_CTX_SIZE=$(XHCI_CTX_SIZE)
+CPPFLAGS := -I. -I../shared -I../user -DXHCI_CTX_SIZE=$(XHCI_CTX_SIZE)
+
 ifeq ($(QEMU),true)
-  CFLAGS += -DQEMU
+  CPPFLAGS += -DQEMU
 endif
 
-LDFLAGS := $(LDFLAGS_BASE) -T $(shell ls *.ld) --defsym=LOAD_ADDR=$(LOAD_ADDR)
+CFLAGS   := $(CFLAGS_BASE) $(CPPFLAGS)
+CXXFLAGS := $(CXXFLAGS_BASE) $(CPPFLAGS)
+LDFLAGS  := $(LDFLAGS_BASE) -T $(shell ls *.ld) --defsym=LOAD_ADDR=$(LOAD_ADDR)
 
 CLEAN_OBJS := $(shell find . -name '*.o')
 CLEAN_DEPS := $(shell find . -name '*.d')
@@ -28,10 +31,12 @@ $(TARGET): ../shared/libshared.a $(OBJ)
 
 %.o: %.S
 	$(CC) $(CFLAGS) -c -MMD -MP $< -o $@
+
 %.o: %.c
-	$(CC) $(CFLAGS) $(CONLY_FLAGS_BASE) -c -MMD -MP $< -o $@
+	$(CC) $(CFLAGS) -c -MMD -MP $< -o $@
+
 %.o: %.cpp
-	$(CC) $(CFLAGS) -fno-rtti -c -MMD -MP $< -o $@
+	$(CXX) $(CXXFLAGS) -c -MMD -MP $< -o $@
 
 clean:
 	$(RM) $(CLEAN_OBJS) $(CLEAN_DEPS) $(ELF) $(TARGET)

--- a/kernel/audio/virtio_audio_pci.cpp
+++ b/kernel/audio/virtio_audio_pci.cpp
@@ -6,10 +6,10 @@
 #include "audio.h"
 
 #define VIRTIO_SND_R_PCM_INFO       0x0100
-#define VIRTIO_SND_R_PCM_SET_PARAMS 0x0101 
-#define VIRTIO_SND_R_PCM_PREPARE    0x0102 
-#define VIRTIO_SND_R_PCM_RELEASE    0x0103 
-#define VIRTIO_SND_R_PCM_START      0x0104 
+#define VIRTIO_SND_R_PCM_SET_PARAMS 0x0101
+#define VIRTIO_SND_R_PCM_PREPARE    0x0102
+#define VIRTIO_SND_R_PCM_RELEASE    0x0103
+#define VIRTIO_SND_R_PCM_START      0x0104
 #define VIRTIO_SND_R_PCM_STOP       0x0105
 
 #define VIRTIO_SND_S_OK         0x8000
@@ -17,7 +17,7 @@
 #define VIRTIO_SND_S_NOT_SUPP   0x8002
 #define VIRTIO_SND_S_IO_ERR     0x8003
 
-#define VIRTIO_SND_PCM_FMT_U32      18 
+#define VIRTIO_SND_PCM_FMT_U32      18
 #define VIRTIO_SND_PCM_FMT_FLOAT    19
 #define VIRTIO_SND_PCM_FMT_FLOAT64  20
 
@@ -38,49 +38,49 @@
 #define VIRTIO_SND_D_OUTPUT 0
 #define VIRTIO_SND_D_INPUT  1
 
-typedef struct virtio_snd_hdr { 
-    uint32_t code; 
-} virtio_snd_hdr; 
+typedef struct virtio_snd_hdr {
+    uint32_t code;
+} virtio_snd_hdr;
 static_assert(sizeof(virtio_snd_hdr) == 4, "Sound header must be 4 bytes");
 
-typedef struct virtio_snd_query_info { 
-    virtio_snd_hdr hdr; 
-    uint32_t start_id; 
-    uint32_t count; 
-    uint32_t size; 
+typedef struct virtio_snd_query_info {
+    virtio_snd_hdr hdr;
+    uint32_t start_id;
+    uint32_t count;
+    uint32_t size;
 } virtio_snd_query_info;
 static_assert(sizeof(virtio_snd_query_info) == 16, "Query info struct must be 16 bytes");
 
-typedef struct virtio_snd_pcm_hdr { 
-    virtio_snd_hdr hdr; 
-    uint32_t stream_id; 
-} virtio_snd_pcm_hdr; 
+typedef struct virtio_snd_pcm_hdr {
+    virtio_snd_hdr hdr;
+    uint32_t stream_id;
+} virtio_snd_pcm_hdr;
 
-typedef struct virtio_snd_info_hdr { 
-    uint32_t hda_fn_nid; 
+typedef struct virtio_snd_info_hdr {
+    uint32_t hda_fn_nid;
 } virtio_snd_info_hdr;
 
-typedef struct virtio_snd_pcm_info { 
-    virtio_snd_info_hdr info_hdr; 
-    uint32_t features; /* 1 << VIRTIO_SND_PCM_F_XXX */ 
-    uint64_t formats; /* 1 << VIRTIO_SND_PCM_FMT_XXX */ 
-    uint64_t rates; /* 1 << VIRTIO_SND_PCM_RATE_XXX */ 
-    uint8_t direction; 
-    uint8_t channels_min; 
-    uint8_t channels_max; 
- 
-    uint8_t padding[5]; 
+typedef struct virtio_snd_pcm_info {
+    virtio_snd_info_hdr info_hdr;
+    uint32_t features; /* 1 << VIRTIO_SND_PCM_F_XXX */
+    uint64_t formats; /* 1 << VIRTIO_SND_PCM_FMT_XXX */
+    uint64_t rates; /* 1 << VIRTIO_SND_PCM_RATE_XXX */
+    uint8_t direction;
+    uint8_t channels_min;
+    uint8_t channels_max;
+
+    uint8_t padding[5];
 }__attribute__((packed)) virtio_snd_pcm_info;
 static_assert(sizeof(virtio_snd_pcm_info) == 32, "PCM Info must be 32");
 
-typedef struct virtio_snd_event { 
-    struct virtio_snd_hdr hdr; 
-    uint32_t data; 
+typedef struct virtio_snd_event {
+    struct virtio_snd_hdr hdr;
+    uint32_t data;
 }__attribute__((packed)) virtio_snd_event;
 
 bool VirtioAudioDriver::init(){
     uint64_t addr = find_pci_device(VIRTIO_VENDOR, VIRTIO_AUDIO_ID);
-    if (!addr){ 
+    if (!addr){
         kprintf("Disk device not found");
         return false;
     }
@@ -142,14 +142,14 @@ void VirtioAudioDriver::config_jacks(){
 
 }
 
-typedef struct virtio_snd_pcm_xfer { 
-    uint32_t stream_id; 
-}__attribute__((packed)) virtio_snd_pcm_xfer; 
- 
-typedef struct virtio_snd_pcm_status { 
-    uint32_t status; 
-    uint32_t latency_bytes; 
-}__attribute__((packed)) virtio_snd_pcm_status; 
+typedef struct virtio_snd_pcm_xfer {
+    uint32_t stream_id;
+}__attribute__((packed)) virtio_snd_pcm_xfer;
+
+typedef struct virtio_snd_pcm_status {
+    uint32_t status;
+    uint32_t latency_bytes;
+}__attribute__((packed)) virtio_snd_pcm_status;
 
 bool VirtioAudioDriver::config_streams(uint32_t streams){
     virtio_snd_query_info* cmd = (virtio_snd_query_info*)kalloc(audio_dev.memory_page, sizeof(virtio_snd_query_info), ALIGN_4KB, true, true);
@@ -159,7 +159,7 @@ bool VirtioAudioDriver::config_streams(uint32_t streams){
     cmd->size = sizeof(virtio_snd_pcm_info);
 
     size_t resp_size = sizeof(virtio_snd_hdr) + (streams * cmd->size);
-    
+
     uintptr_t resp = (uintptr_t)kalloc(audio_dev.memory_page, resp_size, ALIGN_64B, true, true);
 
     if (!virtio_send(&audio_dev, audio_dev.common_cfg->queue_desc, audio_dev.common_cfg->queue_driver, audio_dev.common_cfg->queue_device,
@@ -170,7 +170,7 @@ bool VirtioAudioDriver::config_streams(uint32_t streams){
     }
 
     uint8_t *streams_bytes = (uint8_t*)(resp + sizeof(virtio_snd_hdr));
-    
+
     virtio_snd_pcm_info *stream_info = (virtio_snd_pcm_info*)streams_bytes;
     for (uint32_t stream = 0; stream < streams; stream++){
         uint64_t format = read_unaligned64(&stream_info[stream].formats);
@@ -198,20 +198,21 @@ bool VirtioAudioDriver::config_streams(uint32_t streams){
         if (stream_info[stream].direction == VIRTIO_SND_D_OUTPUT){
             kprintf("Playing from stream %i",stream);
             select_queue(&audio_dev, TRANSMIT_QUEUE);
-        
+
             for (uint16_t i = 0; i < 100; i++){
                 size_t total_size = sizeof(virtio_snd_pcm_status) + sizeof(virtio_snd_pcm_xfer) + TOTAL_BUF_SIZE;
                 uintptr_t full_buffer = (uintptr_t)kalloc(audio_dev.memory_page, total_size, ALIGN_4KB, true, true);
                 virtio_snd_pcm_xfer *header = (virtio_snd_pcm_xfer*)full_buffer;
 
                 header->stream_id = stream;
-                
+
                 uint32_t *buf = (uint32_t*)(full_buffer + sizeof(virtio_snd_pcm_xfer));
                 uint32_t buf_size = TOTAL_BUF_SIZE/SND_U32_BYTES;
                 for (uint32_t sample = 0; sample < buf_size; sample++){
+                    // TODO: what is meant here? GCC suggests parentheses
                     buf[sample] = sample < buf_size/2 == 0 ? 0x88888888 : UINT32_MAX;
                 }
-                
+
                 virtio_send_1d(&audio_dev, full_buffer, total_size);
 
             }
@@ -223,16 +224,16 @@ bool VirtioAudioDriver::config_streams(uint32_t streams){
     return true;
 }
 
-typedef struct virtio_snd_pcm_set_params { 
+typedef struct virtio_snd_pcm_set_params {
     virtio_snd_pcm_hdr hdr;
-    uint32_t buffer_bytes; 
-    uint32_t period_bytes; 
-    uint32_t features; 
-    uint8_t channels; 
-    uint8_t format; 
-    uint8_t rate; 
- 
-    uint8_t padding; 
+    uint32_t buffer_bytes;
+    uint32_t period_bytes;
+    uint32_t features;
+    uint8_t channels;
+    uint8_t format;
+    uint8_t rate;
+
+    uint8_t padding;
 }__attribute__((packed)) virtio_snd_pcm_set_params;
 static_assert(sizeof(virtio_snd_pcm_set_params) == 24, "Virtio sound Set Params command needs to be n bytes");
 
@@ -252,7 +253,7 @@ bool VirtioAudioDriver::stream_set_params(uint32_t stream_id, uint32_t features,
 
     bool result = virtio_send(&audio_dev, audio_dev.common_cfg->queue_desc, audio_dev.common_cfg->queue_driver, audio_dev.common_cfg->queue_device,
         (uintptr_t)cmd, sizeof(virtio_snd_pcm_set_params), (uintptr_t)resp, sizeof(virtio_snd_info_hdr), VIRTQ_DESC_F_WRITE);
-    
+
     kfree(cmd, sizeof(virtio_snd_query_info));
     kfree((void*)resp, sizeof(virtio_snd_info_hdr));
 
@@ -261,7 +262,7 @@ bool VirtioAudioDriver::stream_set_params(uint32_t stream_id, uint32_t features,
 
     if (result)
         result = send_simple_stream_cmd(stream_id, VIRTIO_SND_R_PCM_START);
-    
+
     return result;
 }
 
@@ -270,15 +271,15 @@ bool VirtioAudioDriver::send_simple_stream_cmd(uint32_t stream_id, uint32_t comm
     virtio_snd_pcm_hdr* cmd = (virtio_snd_pcm_hdr*)kalloc(audio_dev.memory_page, sizeof(virtio_snd_pcm_hdr), ALIGN_4KB, true, true);
     cmd->hdr.code = command;
     cmd->stream_id = stream_id;
-    
+
     virtio_snd_info_hdr *resp = (virtio_snd_info_hdr*)kalloc(audio_dev.memory_page, sizeof(virtio_snd_info_hdr), ALIGN_64B, true, true);
-    
+
     bool result = virtio_send(&audio_dev, audio_dev.common_cfg->queue_desc, audio_dev.common_cfg->queue_driver, audio_dev.common_cfg->queue_device,
         (uintptr_t)cmd, sizeof(virtio_snd_pcm_hdr), (uintptr_t)resp, sizeof(virtio_snd_info_hdr), VIRTQ_DESC_F_WRITE);
 
     kfree(cmd, sizeof(virtio_snd_query_info));
     kfree((void*)resp, sizeof(virtio_snd_info_hdr));
-    
+
     return result;
 }
 

--- a/kernel/console/kio.c
+++ b/kernel/console/kio.c
@@ -27,6 +27,7 @@ size_t console_read(file *fd, char *out_buf, size_t size, file_offset offset){
 
 size_t console_write(file *fd, const char *buf, size_t size, file_offset offset){
     kprintf(buf);
+    return size;
 }
 
 
@@ -72,7 +73,7 @@ void kprintf(const char *fmt, ...){
     va_list args;
     va_start(args, fmt);
     char* buf = kalloc(print_buf, 256, ALIGN_64B, true, false);
-    size_t len = string_format_va_buf(fmt, buf, args);
+    string_format_va_buf(fmt, buf, args);
     va_end(args);
     puts(buf);
     putc('\r');
@@ -92,7 +93,7 @@ void kputf(const char *fmt, ...){
     va_list args;
     va_start(args, fmt);
     char* buf = kalloc(print_buf, 256, ALIGN_64B, true, false);
-    size_t len = string_format_va_buf(fmt, buf, args);
+    string_format_va_buf(fmt, buf, args);
     va_end(args);
     puts(buf);
     // kfree((void*)buf, 256);

--- a/kernel/input/input_dispatch.cpp
+++ b/kernel/input/input_dispatch.cpp
@@ -107,12 +107,12 @@ bool sys_shortcut_triggered(uint16_t pid, uint16_t sid){
     if (shortcuts[sid].pid == pid && shortcuts[sid].triggered){
         shortcuts[sid].triggered = false;
         return true;
-    } 
+    }
     return false;
 }
 
 bool input_init(){
-    for (int i = 0; i < 16; i++) shortcuts[i] = (shortcut){0};
+    for (int i = 0; i < 16; i++) shortcuts[i] = {};
     if (BOARD_TYPE == 2 && RPI_BOARD != 5){
         input_driver = new DWC2Driver();//TODO: QEMU & 3 Only
         return input_driver->init();

--- a/kernel/input/usb.cpp
+++ b/kernel/input/usb.cpp
@@ -24,7 +24,7 @@ bool USBDriver::setup_device(uint8_t address, uint16_t port){
         return false;
     }
     usb_device_descriptor* descriptor = (usb_device_descriptor*)kalloc(mem_page, sizeof(usb_device_descriptor), ALIGN_64B, true, true);
-    
+
     if (!request_descriptor(address, 0, 0x80, 6, USB_DEVICE_DESCRIPTOR, 0, 0, descriptor)){
         kprintf("[USB error] failed to get device descriptor");
         return false;
@@ -104,7 +104,7 @@ bool USBDriver::get_configuration(uint8_t address){
     uint8_t* report_descriptor;
     uint16_t report_length;
 
-    usb_device_types dev_type;
+    usb_device_types dev_type = UNKNOWN;
 
     kprintf("[USB] set configuration %i for device %i", config->bConfigurationValue, address);
     request_sized_descriptor(address, 0, 0, 9, 0, config->bConfigurationValue, 0, 0, 0);
@@ -136,7 +136,7 @@ bool USBDriver::get_configuration(uint8_t address){
             case 0x1:
                 dev_type = KEYBOARD;
                 break;
-            
+
             default:
                 dev_type = UNKNOWN;
                 break;
@@ -160,7 +160,7 @@ bool USBDriver::get_configuration(uint8_t address){
         }
         case 0x5: {//Endpoint
             usb_endpoint_descriptor *endpoint = (usb_endpoint_descriptor*)&config->data[i];
-            
+
             if (dev_type != UNKNOWN)
                 configure_endpoint(address, endpoint, config->bConfigurationValue, dev_type);
 
@@ -173,7 +173,7 @@ bool USBDriver::get_configuration(uint8_t address){
     }
 
     return true;
-    
+
 }
 
 bool USBDriver::request_descriptor(uint8_t address, uint8_t endpoint, uint8_t rType, uint8_t request, uint8_t type, uint16_t index, uint16_t wIndex, void *out_descriptor){

--- a/kernel/input/xhci.cpp
+++ b/kernel/input/xhci.cpp
@@ -480,7 +480,7 @@ uint32_t XHCIDriver::calculate_interval(uint32_t speed, uint32_t received_interv
 
 	uint32_t i;
 	for (i = 3; i < 11; i++)
-		if (125 * (1 << i) >= 1000 * received_interval) break;
+		if (125u * (1 << i) >= 1000 * received_interval) break;
 
 	return i;
 }

--- a/kernel/input/xhci.cpp
+++ b/kernel/input/xhci.cpp
@@ -57,7 +57,7 @@ bool XHCIDriver::check_fatal_error() {
 #define XHCI_EP_CONTROL 4
 
 bool XHCIDriver::init(){
-    uint64_t addr, mmio, mmio_size;
+    uint64_t addr = 0, mmio, mmio_size;
     bool use_pci = false;
     use_interrupts = true;
     if (XHCI_BASE){

--- a/kernel/input/xhci.cpp
+++ b/kernel/input/xhci.cpp
@@ -418,8 +418,6 @@ bool XHCIDriver::request_sized_descriptor(uint8_t address, uint8_t endpoint, uin
 
     // kprintf("RT: %x R: %x V: %x I: %x L: %x",packet.bmRequestType,packet.bRequest,packet.wValue,packet.wIndex,packet.wLength);
 
-    bool is_in = (rType & 0x80) != 0;
-
     xhci_ring *transfer_ring = &endpoint_map[address << 8 | endpoint];
 
     trb* setup_trb = &transfer_ring->ring[transfer_ring->index++];

--- a/kernel/kernel_processes/monitor/monitor_processes.c
+++ b/kernel/kernel_processes/monitor/monitor_processes.c
@@ -23,7 +23,7 @@ char* parse_proc_state(int state){
     case RUNNING:
     case BLOCKED:
         return "Running";
-    
+
     default:
         return "Invalid";
     }
@@ -96,7 +96,7 @@ void draw_process_view(){
         int index = scroll_index;
         int valid_count = 0;
 
-        process_t *proc;
+        process_t *proc = NULL;
         while (index < MAX_PROCS) {
             proc = &processes[index];
             if (proc->id != 0 && proc->state != STOPPED) {
@@ -107,6 +107,8 @@ void draw_process_view(){
             }
             index++;
         }
+
+        if (!proc) continue; // TODO: panic?
 
         if (proc->id == 0 || valid_count < i || proc->state == STOPPED) break;
 
@@ -127,11 +129,11 @@ void draw_process_view(){
 
         gpu_draw_string(name, (gpu_point){xo, name_y}, scale, BG_COLOR);
         gpu_draw_string(state, (gpu_point){xo, state_y}, scale, BG_COLOR);
-        
+
         string pc = string_from_hex(proc->pc);
         gpu_draw_string(pc, (gpu_point){xo, pc_y}, scale, BG_COLOR);
         free(pc.data, pc.mem_length);
-        
+
         draw_memory("Stack", xo, stack_y, stack_width, stack_height, proc->stack - proc->sp, proc->stack_size);
         uint64_t heap = calc_heap(proc->heap);
         uint64_t heap_limit = ((heap + 0xFFF) & ~0xFFF);
@@ -160,7 +162,7 @@ void monitor_procs(){
         if (sys_shortcut_triggered_current(shortcut)){
             if (active)
                 pause_window_draw();
-            else 
+            else
                 resume_window_draw();
             active = !active;
         }
@@ -172,7 +174,7 @@ void monitor_procs(){
 process_t* start_process_monitor(){
 #if QEMU
     return create_kernel_process("procmonitor",monitor_procs);
-#else 
+#else
     //TODO: disabled process monitor since shortcuts seem broken on rpi
     return 0x0;//create_kernel_process("procmonitor",monitor_procs);
 #endif

--- a/kernel/networking/network.cpp
+++ b/kernel/networking/network.cpp
@@ -34,7 +34,7 @@ int net_rx_frame(sizedptr *out_frame) {
 }
 
 const net_l2l3_endpoint* network_get_local_endpoint() {
-    static net_l2l3_endpoint dummy = {0};
+    static net_l2l3_endpoint dummy = {};
     return dispatch ? &dispatch->get_local_ep() : &dummy;
 }
 

--- a/kernel/networking/network_dispatch.cpp
+++ b/kernel/networking/network_dispatch.cpp
@@ -37,7 +37,7 @@ bool NetworkDispatch::init()
 void NetworkDispatch::handle_download_interrupt()
 {
     if (!driver) return;
-    
+
     sizedptr raw = driver->handle_receive_packet(recv_buffer);
     if (raw.size < sizeof(eth_hdr_t)) {
         return;
@@ -125,21 +125,6 @@ bool NetworkDispatch::dequeue_packet_for(uint16_t pid, sizedptr *out)
 
     free(reinterpret_cast<void*>(stored.ptr), stored.size);
     return true;
-}
-
-static sizedptr make_user_copy(const sizedptr &src)
-{
-    sizedptr out{0, 0};
-    uintptr_t mem = malloc(src.size);
-    if (!mem) return out;
-
-    memcpy(reinterpret_cast<void*>(mem),
-           reinterpret_cast<const void*>(src.ptr),
-           src.size);
-
-    out.ptr  = mem;
-    out.size = src.size;
-    return out;
 }
 
 sizedptr NetworkDispatch::make_copy(const sizedptr &in)

--- a/kernel/networking/port_manager.c
+++ b/kernel/networking/port_manager.c
@@ -5,9 +5,6 @@
 
 static port_entry_t g_port_table[PROTO_COUNT][MAX_PORTS];//tab proto/port
 
-static inline bool port_valid(uint16_t p) {
-    return p > 0 && p < MAX_PORTS;
-}
 static inline bool proto_valid(protocol_t proto) {
     return (uint32_t)proto< PROTO_COUNT;
 }
@@ -44,7 +41,7 @@ bool port_bind_manual(protocol_t proto,
                       uint16_t pid,
                       port_recv_handler_t handler)
 {
-    if (!proto_valid(proto) || !port_valid(port)) return false;
+    if (!proto_valid(proto)) return false;
     port_entry_t *e = &g_port_table[proto][port];
     if (e->used) return false;
     e->used = true;
@@ -57,7 +54,7 @@ bool port_unbind(protocol_t proto,
                  uint16_t port,
                  uint16_t pid)
 {
-    if (!proto_valid(proto) || !port_valid(port)) return false;
+    if (!proto_valid(proto)) return false;
     port_entry_t *e = &g_port_table[proto][port];
     if (!e->used || e->pid != pid) return false;
     e->used = false;
@@ -80,17 +77,17 @@ void port_unbind_all(uint16_t pid) {
 }
 
 bool port_is_bound(protocol_t proto, uint16_t port) {
-    if (!proto_valid(proto) || !port_valid(port)) return false;
+    if (!proto_valid(proto)) return false;
     return g_port_table[proto][port].used;
 }
 
 uint16_t port_owner_of(protocol_t proto, uint16_t port) {
-    if (!proto_valid(proto) || !port_valid(port)) return PORT_FREE_OWNER;
+    if (!proto_valid(proto)) return PORT_FREE_OWNER;
     return g_port_table[proto][port].pid;
 }
 
 port_recv_handler_t port_get_handler(protocol_t proto, uint16_t port) {
-    if (!proto_valid(proto) || !port_valid(port)) return NULL;
+    if (!proto_valid(proto)) return NULL;
     return g_port_table[proto][port].used
         ? g_port_table[proto][port].handler
         : NULL;

--- a/kernel/networking/port_manager.c
+++ b/kernel/networking/port_manager.c
@@ -24,13 +24,13 @@ int port_alloc_ephemeral(protocol_t proto,
                          port_recv_handler_t handler)
 {
     if (!proto_valid(proto)) return -1;
-    for (uint16_t p = PORT_MIN_EPHEMERAL; p <= PORT_MAX_EPHEMERAL; ++p) {
+    for (int p = PORT_MIN_EPHEMERAL; p <= PORT_MAX_EPHEMERAL; ++p) {
         port_entry_t *e = &g_port_table[proto][p];
         if (!e->used) {
             e->used = true;
             e->pid = pid;
             e->handler = handler;
-            return (int)p;
+            return p;
         }
     }
     return -1;
@@ -65,7 +65,7 @@ bool port_unbind(protocol_t proto,
 
 void port_unbind_all(uint16_t pid) {
     for (int pr = 0; pr < PROTO_COUNT; ++pr) {
-        for (uint16_t p = 1; p < MAX_PORTS; ++p) {
+        for (int p = 1; p < MAX_PORTS; ++p) {
             port_entry_t *e = &g_port_table[pr][p];
             if (e->used && e->pid == pid) {
                 e->used    = false;

--- a/kernel/process/scheduler.c
+++ b/kernel/process/scheduler.c
@@ -197,7 +197,7 @@ void sleep_process(uint64_t msec){
         sleeping[sleep_count++] = (sleep_tracker){
             .pid = processes[current_proc].id,
             .timestamp = timer_now_msec(),
-            .sleep_time = msec, 
+            .sleep_time = msec,
             .valid = true
         };
     }
@@ -236,7 +236,7 @@ sizedptr list_processes(const char *path){
     void *list_buffer = (char*)malloc(size);
     if (strlen(path, 100) == 0){
         uint32_t count = 0;
-    
+
         char *write_ptr = (char*)list_buffer + 4;
         process_t *processes = get_all_processes();
         for (int i = 0; i < MAX_PROCS; i++){
@@ -266,11 +266,19 @@ FS_RESULT open_proc(const char *path, file *descriptor){
 }
 
 size_t read_proc(file* fd, char *buf, size_t size, file_offset offset){
-
+    (void)fd;
+    (void)buf;
+    (void)size;
+    (void)offset;
+    return 0;
 }
 
 size_t write_proc(file* fd, const char *buf, size_t size, file_offset offset){
-
+    (void)fd;
+    (void)buf;
+    (void)size;
+    (void)offset;
+    return 0;
 }
 
 driver_module scheduler_module = (driver_module){

--- a/shared/Makefile
+++ b/shared/Makefile
@@ -2,10 +2,12 @@
 CFLAGS  := $(CFLAGS_BASE) -I. -I../kernel -Wno-unused-parameter
 
 CLEAN_OBJS := $(shell find . -name '*.o')
+CLEAN_DEPS := $(shell find . -name '*.d')
 C_SRC   := $(shell find . -name '*.c')
 CPP_SRC := $(shell find . -name '*.cpp')
 ASM_SRC := $(shell find . -name '*.S')
 OBJ     := $(C_SRC:.c=.o) $(ASM_SRC:.S=.o) $(CPP_SRC:.cpp=.o)
+DEP     := $(C_SRC:.c=.d) $(ASM_SRC:.S=.d) $(CPP_SRC:.cpp=.d)
 
 TARGET  := libshared.a
 
@@ -17,13 +19,15 @@ $(TARGET): $(OBJ)
 	$(AR) rcs $@ $^
 
 %.o: %.S
-	$(CC) $(CFLAGS) -c $< -o $@
+	$(CC) $(CFLAGS) -c -MMD -MP $< -o $@
 
 %.o: %.c
-	$(CC) $(CFLAGS) $(CONLY_FLAGS_BASE) -c $< -o $@
+	$(CC) $(CFLAGS) $(CONLY_FLAGS_BASE) -c -MMD -MP $< -o $@
 
 %.o: %.cpp
-	$(CC) $(CFLAGS) -fno-rtti -c $< -o $@
+	$(CC) $(CFLAGS) -fno-rtti -c -MMD -MP $< -o $@
 
 clean:
-	rm -f $(CLEAN_OBJS) $(TARGET)
+	rm -f $(CLEAN_OBJS) $(CLEAN_DEPS) $(TARGET)
+
+-include $(DEP)

--- a/shared/Makefile
+++ b/shared/Makefile
@@ -28,6 +28,6 @@ $(TARGET): $(OBJ)
 	$(CC) $(CFLAGS) -fno-rtti -c -MMD -MP $< -o $@
 
 clean:
-	rm -f $(CLEAN_OBJS) $(CLEAN_DEPS) $(TARGET)
+	$(RM) $(CLEAN_OBJS) $(CLEAN_DEPS) $(TARGET)
 
 -include $(DEP)

--- a/shared/Makefile
+++ b/shared/Makefile
@@ -1,4 +1,7 @@
 #shared
+
+include ../common.mk
+
 CPPFLAGS := -I. -I../kernel
 CFLAGS   := $(CFLAGS_BASE) $(CPPFLAGS)
 CXXFLAGS := $(CXXFLAGS_BASE) $(CPPFLAGS)

--- a/shared/Makefile
+++ b/shared/Makefile
@@ -1,5 +1,7 @@
 #shared
-CFLAGS  := $(CFLAGS_BASE) -I. -I../kernel -Wno-unused-parameter
+CPPFLAGS := -I. -I../kernel
+CFLAGS   := $(CFLAGS_BASE) $(CPPFLAGS)
+CXXFLAGS := $(CXXFLAGS_BASE) $(CPPFLAGS)
 
 CLEAN_OBJS := $(shell find . -name '*.o')
 CLEAN_DEPS := $(shell find . -name '*.d')
@@ -22,10 +24,10 @@ $(TARGET): $(OBJ)
 	$(CC) $(CFLAGS) -c -MMD -MP $< -o $@
 
 %.o: %.c
-	$(CC) $(CFLAGS) $(CONLY_FLAGS_BASE) -c -MMD -MP $< -o $@
+	$(CC) $(CFLAGS) -c -MMD -MP $< -o $@
 
 %.o: %.cpp
-	$(CC) $(CFLAGS) -fno-rtti -c -MMD -MP $< -o $@
+	$(CXX) $(CXXFLAGS) -c -MMD -MP $< -o $@
 
 clean:
 	$(RM) $(CLEAN_OBJS) $(CLEAN_DEPS) $(TARGET)

--- a/shared/Makefile
+++ b/shared/Makefile
@@ -18,16 +18,16 @@ TARGET  := libshared.a
 all: $(TARGET)
 
 $(TARGET): $(OBJ)
-	$(AR) rcs $@ $^
+	$(VAR) rcs $@ $^
 
 %.o: %.S
-	$(CC) $(CFLAGS) -c -MMD -MP $< -o $@
+	$(VAS) $(CFLAGS) -c $< -o $@
 
 %.o: %.c
-	$(CC) $(CFLAGS) -c -MMD -MP $< -o $@
+	$(VCC) $(CFLAGS) -c -MMD -MP $< -o $@
 
 %.o: %.cpp
-	$(CXX) $(CXXFLAGS) -c -MMD -MP $< -o $@
+	$(VCXX) $(CXXFLAGS) -c -MMD -MP $< -o $@
 
 clean:
 	$(RM) $(CLEAN_OBJS) $(CLEAN_DEPS) $(TARGET)

--- a/shared/net/application_layer/csocket_http_client.cpp
+++ b/shared/net/application_layer/csocket_http_client.cpp
@@ -13,6 +13,7 @@ extern "C" {
 http_client_handle_t http_client_create(uint16_t pid) {
     uintptr_t mem = malloc(sizeof(HTTPClient));
     if (!mem) return NULL;
+    // TODO: check for correct fix here
     HTTPClient *cli = reinterpret_cast<HTTPClient*>( (void*)mem );
     return reinterpret_cast<http_client_handle_t>(new HTTPClient(pid));
 }

--- a/shared/net/application_layer/csocket_http_client.cpp
+++ b/shared/net/application_layer/csocket_http_client.cpp
@@ -1,6 +1,5 @@
-#pragma once
 #include "csocket_http_client.h"
-#include "socket_http_client.hpp" 
+#include "socket_http_client.hpp"
 #include "net/transport_layer/socket_tcp.hpp"
 
 extern "C" {

--- a/shared/net/application_layer/csocket_http_server.cpp
+++ b/shared/net/application_layer/csocket_http_server.cpp
@@ -12,6 +12,7 @@ extern "C" {
 http_server_handle_t http_server_create(uint16_t pid) {
     void* raw = (void*)malloc(sizeof(HTTPServer));
     if (!raw) return nullptr;
+    // TODO: check for correct fix here
     HTTPServer* srv = reinterpret_cast<HTTPServer*>(raw);
     return reinterpret_cast<http_server_handle_t>(new HTTPServer(pid));
 }

--- a/shared/net/application_layer/dhcp.c
+++ b/shared/net/application_layer/dhcp.c
@@ -5,8 +5,6 @@
 #include "types.h"
 #include "net/transport_layer/csocket_udp.h"
 
-static socket_handle_t g_dhcp_socket = NULL;
-
 extern uintptr_t malloc(uint64_t size);
 extern void      free(void *ptr, uint64_t size);
 extern void      sleep(uint64_t ms);

--- a/shared/net/application_layer/dhcp.c
+++ b/shared/net/application_layer/dhcp.c
@@ -67,10 +67,10 @@ uint16_t dhcp_parse_option(const dhcp_packet *p, uint16_t wanted) {
         }
         i += len;
     }
-    return UINT16_MAX; 
+    return UINT16_MAX;
 }
 
 uint8_t dhcp_option_len(const dhcp_packet *p, uint16_t idx) {
-    if (idx == 0 || idx + 1 >= sizeof(p->options)) return 0;
+    if (idx == 0 || idx + 1u >= sizeof(p->options)) return 0;
     return p->options[idx+1];
 }

--- a/shared/net/internet_layer/icmp.c
+++ b/shared/net/internet_layer/icmp.c
@@ -53,10 +53,7 @@ void create_icmp_packet(uintptr_t p,
     pkt->id   = __builtin_bswap16(d->id);
     pkt->seq  = __builtin_bswap16(d->seq);
 
-    if (d->payload)
-        memcpy(pkt->payload, d->payload, 56);
-    else
-        memset(pkt->payload, 0, 56);
+    memcpy(pkt->payload, d->payload, 56);
 
     pkt->checksum = 0;
 }

--- a/shared/net/internet_layer/ipv4.c
+++ b/shared/net/internet_layer/ipv4.c
@@ -106,7 +106,6 @@ void ip_input(uintptr_t ip_ptr,
     arp_table_put(sip, src_mac, 60000, false);
 
     uint32_t dip = __builtin_bswap32(hdr->dst_ip);
-    const net_cfg_t *cfg = ipv4_get_cfg(); //TODO manage special ip
 
     uintptr_t payload_ptr = ip_ptr + header_bytes;
     uint32_t payload_len = __builtin_bswap16(hdr->total_length) - header_bytes;

--- a/shared/net/transport_layer/csocket_tcp.cpp
+++ b/shared/net/transport_layer/csocket_tcp.cpp
@@ -1,4 +1,3 @@
-#pragma once
 #include "net/transport_layer/socket_tcp.hpp"
 #include "net/transport_layer/socket.hpp"
 #include "csocket_tcp.h"

--- a/shared/net/transport_layer/csocket_udp.cpp
+++ b/shared/net/transport_layer/csocket_udp.cpp
@@ -1,4 +1,3 @@
-#pragma once
 #include "net/transport_layer/socket_udp.hpp"
 #include "net/transport_layer/socket.hpp"
 #include "csocket_udp.h"

--- a/shared/net/transport_layer/socket_tcp.hpp
+++ b/shared/net/transport_layer/socket_tcp.hpp
@@ -11,7 +11,7 @@
 
 #define KP(fmt, ...) \
     do { kprintf(fmt, ##__VA_ARGS__); } while (0)
-    
+
 extern "C" {
     void      sleep(uint64_t ms);
     uintptr_t malloc(uint64_t size);
@@ -154,7 +154,7 @@ public:
         flow->payload = { (uintptr_t)buf, (uint32_t)len };
         flow->flags = (1<<PSH_F) | (1<<ACK_F);
         tcp_result_t res = tcp_flow_send(flow);
-        return (res == TCP_OK) ? (int64_t)len : res;
+        return (res == TCP_OK) ? (int64_t)len : (int64_t)res;
     }
 
     int64_t recv(void* buf, uint64_t len) {
@@ -188,7 +188,7 @@ public:
     }
 
     int32_t close_client() {
-        
+
         if (connected && flow) {
             tcp_flow_close(flow);
             connected = false;

--- a/shared/net/transport_layer/tcp.c
+++ b/shared/net/transport_layer/tcp.c
@@ -422,7 +422,6 @@ void tcp_input(uintptr_t ptr, uint32_t len, uint32_t src_ip, uint32_t dst_ip) {
     uint32_t seq = ntohl(hdr->sequence);
     uint32_t ack = ntohl(hdr->ack);
     uint8_t flags = hdr->flags;
-    uint16_t window = ntohs(hdr->window);
     int idx = find_flow(dst_port, src_ip, src_port);
     tcp_flow_t *flow = (idx >= 0 ? &tcp_flows[idx] : NULL);
 
@@ -432,7 +431,6 @@ void tcp_input(uintptr_t ptr, uint32_t len, uint32_t src_ip, uint32_t dst_ip) {
             //TODO: use a syscall for the rng
             rng_t rng;
             rng_init_random(&rng);
-            tcp_flow_t *lf = &tcp_flows[listen_idx];
             int new_idx = allocate_flow_entry();
             if (new_idx < 0) return;
 

--- a/shared/net/transport_layer/tcp.c
+++ b/shared/net/transport_layer/tcp.c
@@ -543,6 +543,7 @@ void tcp_input(uintptr_t ptr, uint32_t len, uint32_t src_ip, uint32_t dst_ip) {
             );
             return;
         }
+        // fall-through
     case TCP_FIN_WAIT_1:
     case TCP_FIN_WAIT_2:
     case TCP_CLOSE_WAIT:

--- a/shared/net/transport_layer/tcp.h
+++ b/shared/net/transport_layer/tcp.h
@@ -71,7 +71,7 @@ typedef enum {
 typedef struct {
     uint16_t local_port;
     net_l4_endpoint remote;
-    tcp_state_t state; 
+    tcp_state_t state;
     tcp_data ctx;
     uint8_t retries;
 } tcp_flow_t;
@@ -80,8 +80,6 @@ typedef struct {
 #define TCP_SYN_RETRIES 5
 #define TCP_DATA_RETRIES 5
 #define TCP_RETRY_TIMEOUT_MS 1000
-
-static int find_flow(uint16_t local_port, uint32_t remote_ip, uint16_t remote_port);
 
 tcp_data* tcp_get_ctx(uint16_t local_port,
                     uint32_t remote_ip,

--- a/user/Makefile
+++ b/user/Makefile
@@ -1,4 +1,7 @@
 #user
+
+include ../common.mk
+
 CPPFLAGS := -I. -I../shared
 CFLAGS   := $(CFLAGS_BASE) $(CPPFLAGS)
 CXXFLAGS := $(CXXFLAGS_BASE) $(CPPFLAGS)

--- a/user/Makefile
+++ b/user/Makefile
@@ -1,6 +1,8 @@
 #user
-CFLAGS  := $(CFLAGS_BASE) -I. -I../shared -Wno-unused-parameter
-LDFLAGS := -T $(shell ls *.ld)
+CPPFLAGS := -I. -I../shared
+CFLAGS   := $(CFLAGS_BASE) $(CPPFLAGS)
+CXXFLAGS := $(CXXFLAGS_BASE) $(CPPFLAGS)
+LDFLAGS  := -T $(shell ls *.ld)
 
 CLEAN_OBJS := $(shell find . -name '*.o')
 CLEAN_DEPS := $(shell find . -name '*.d')
@@ -26,10 +28,10 @@ $(LOCATION)$(TARGET): $(OBJ)
 	$(CC) $(CFLAGS) -c -MMD -MP $< -o $@
 
 %.o: %.c
-	$(CC) $(CFLAGS) $(CONLY_FLAGS_BASE) -c -MMD -MP $< -o $@
+	$(CC) $(CFLAGS) -c -MMD -MP $< -o $@
 
 %.o: %.cpp
-	$(CC) $(CFLAGS) -fno-rtti -c -MMD -MP $< -o $@
+	$(CXX) $(CXXFLAGS) -c -MMD -MP $< -o $@
 
 clean:
 	$(RM) $(CLEAN_OBJS) $(CLEAN_DEPS) $(TARGET)

--- a/user/Makefile
+++ b/user/Makefile
@@ -3,9 +3,11 @@ CFLAGS  := $(CFLAGS_BASE) -I. -I../shared -Wno-unused-parameter
 LDFLAGS := -T $(shell ls *.ld)
 
 CLEAN_OBJS := $(shell find . -name '*.o')
+CLEAN_DEPS := $(shell find . -name '*.d')
 C_SRC   := $(shell find . -name '*.c')
 CPP_SRC := $(shell find . -name '*.cpp')
 OBJ     := $(C_SRC:.c=.o) $(CPP_SRC:.cpp=.o)
+DEP     := $(C_SRC:.c=.d) $(CPP_SRC:.cpp=.d)
 
 NAME     := $(notdir $(CURDIR))
 ELF      := $(NAME).elf
@@ -21,13 +23,15 @@ $(LOCATION)$(TARGET): $(OBJ)
 	$(OBJCOPY) -O binary $(LOCATION)$(ELF) $@
 
 %.o: %.S
-	$(CC) $(CFLAGS) -c $< -o $@
+	$(CC) $(CFLAGS) -c -MMD -MP $< -o $@
 
 %.o: %.c
-	$(CC) $(CFLAGS) $(CONLY_FLAGS_BASE) -c $< -o $@
+	$(CC) $(CFLAGS) $(CONLY_FLAGS_BASE) -c -MMD -MP $< -o $@
 
 %.o: %.cpp
-	$(CC) $(CFLAGS) -fno-rtti -c $< -o $@
+	$(CC) $(CFLAGS) -fno-rtti -c -MMD -MP $< -o $@
 
 clean:
-	rm -f $(CLEAN_OBJS) $(TARGET)
+	rm -f $(CLEAN_OBJS) $(CLEAN_DEPS) $(TARGET)
+
+-include $(DEP)

--- a/user/Makefile
+++ b/user/Makefile
@@ -21,17 +21,17 @@ LOCATION := ../fs/redos/user/
 all: $(LOCATION)$(TARGET)
 
 $(LOCATION)$(TARGET): $(OBJ)
-	$(LD) $(LDFLAGS) -o $(LOCATION)$(ELF) $(OBJ) ../shared/libshared.a
+	$(VLD) $(LDFLAGS) -o $(LOCATION)$(ELF) $(OBJ) ../shared/libshared.a
 	$(OBJCOPY) -O binary $(LOCATION)$(ELF) $@
 
 %.o: %.S
-	$(CC) $(CFLAGS) -c -MMD -MP $< -o $@
+	$(VAS) $(CFLAGS) -c $< -o $@
 
 %.o: %.c
-	$(CC) $(CFLAGS) -c -MMD -MP $< -o $@
+	$(VCC) $(CFLAGS) -c -MMD -MP $< -o $@
 
 %.o: %.cpp
-	$(CXX) $(CXXFLAGS) -c -MMD -MP $< -o $@
+	$(VCXX) $(CXXFLAGS) -c -MMD -MP $< -o $@
 
 clean:
 	$(RM) $(CLEAN_OBJS) $(CLEAN_DEPS) $(TARGET)

--- a/user/Makefile
+++ b/user/Makefile
@@ -32,6 +32,6 @@ $(LOCATION)$(TARGET): $(OBJ)
 	$(CC) $(CFLAGS) -fno-rtti -c -MMD -MP $< -o $@
 
 clean:
-	rm -f $(CLEAN_OBJS) $(CLEAN_DEPS) $(TARGET)
+	$(RM) $(CLEAN_OBJS) $(CLEAN_DEPS) $(TARGET)
 
 -include $(DEP)


### PR DESCRIPTION
A few more legit compile warnings found by enabling compiler optimizations.

Depends on #27 

As was mentioned on-stream, enabling optimizations breaks everything due to missing volatiles and such, but these look simple/legit.