### PR TITLE
Fix some "may be used uninitialized" warnings

### DIFF
--- a/kernel/console/kconsole/terminal.cpp
+++ b/kernel/console/kconsole/terminal.cpp
@@ -70,7 +70,7 @@ void Terminal::run_command(){
     string cmd;
     int argc = 0;
     const char** argv; 
-    string args_copy;
+    string args_copy = {};
     
     if (fullcmd == args){
         cmd = string_l(fullcmd);

--- a/kernel/input/usb.cpp
+++ b/kernel/input/usb.cpp
@@ -104,7 +104,7 @@ bool USBDriver::get_configuration(uint8_t address){
     uint8_t* report_descriptor;
     uint16_t report_length;
 
-    usb_device_types dev_type;
+    usb_device_types dev_type = UNKNOWN;
 
     kprintf("[USB] set configuration %i for device %i", config->bConfigurationValue, address);
     request_sized_descriptor(address, 0, 0, 9, 0, config->bConfigurationValue, 0, 0, 0);

--- a/kernel/input/xhci.cpp
+++ b/kernel/input/xhci.cpp
@@ -57,7 +57,7 @@ bool XHCIDriver::check_fatal_error() {
 #define XHCI_EP_CONTROL 4
 
 bool XHCIDriver::init(){
-    uint64_t addr, mmio, mmio_size;
+    uint64_t addr = 0, mmio = 0, mmio_size = 0;
     bool use_pci = false;
     use_interrupts = true;
     if (XHCI_BASE){

--- a/kernel/kernel_processes/monitor/monitor_processes.c
+++ b/kernel/kernel_processes/monitor/monitor_processes.c
@@ -93,7 +93,7 @@ void draw_process_view(){
         int index = scroll_index;
         int valid_count = 0;
 
-        process_t *proc;
+        process_t *proc = NULL;
         while (index < MAX_PROCS) {
             proc = &processes[index];
             if (proc->id != 0 && proc->state != STOPPED) {
@@ -105,7 +105,7 @@ void draw_process_view(){
             index++;
         }
 
-        if (proc->id == 0 || valid_count < i || proc->state == STOPPED) break;
+        if (proc == NULL || proc->id == 0 || valid_count < i || proc->state == STOPPED) break;
 
         string name = string_l((const char*)(uintptr_t)proc->name);
         string state = string_l(parse_proc_state(proc->state));

--- a/kernel/memory/mmu.c
+++ b/kernel/memory/mmu.c
@@ -102,7 +102,7 @@ void mmu_map_4kb(uint64_t va, uint64_t pa, uint64_t attr_index, uint64_t level) 
         return;
     }
     
-    uint8_t permission;
+    uint8_t permission = 0;
     
     switch (level)
     {


### PR DESCRIPTION
Need to enable level 1 or more optimization level for GCC to perform flow-sensitive analysis. These all look like legitimate issues which could cause strange hard-to-find bugs.