### PR TITLE
Fix Make dependencies to support parallel builds (-j)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,10 +18,10 @@ all: shared kernel user
 shared:
 	$(MAKE) -C shared
 
-user: prepare-fs
+user: shared prepare-fs
 	$(MAKE) -C user
 
-kernel:
+kernel: shared
 	$(MAKE) -C kernel LOAD_ADDR=$(LOAD_ADDR) XHCI_CTX_SIZE=$(XHCI_CTX_SIZE) QEMU=$(QEMU)
 
 clean:

--- a/user/Makefile
+++ b/user/Makefile
@@ -26,7 +26,7 @@ all: prepare $(LOCATION)$(TARGET)
 prepare:
 	mkdir -p $(BUILD_DIR)
 
-$(LOCATION)$(TARGET): $(OBJ)
+$(LOCATION)$(TARGET): ../shared/libshared.a $(OBJ)
 	echo $(LDFLAGS) -o $(LOCATION)$(ELF) $(addprefix $(BUILD_DIR)/,$(notdir $(OBJ))) ../shared/libshared.a
 	$(VLD) $(LDFLAGS) -o $(LOCATION)$(ELF) $(addprefix $(BUILD_DIR)/,$(notdir $(OBJ))) ../shared/libshared.a
 	$(OBJCOPY) -O binary $(LOCATION)$(ELF) $@


### PR DESCRIPTION
On my computer (-j12) the build time is reduced from around 9.5 seconds to around 4 seconds.

Use like: `make -j$(nproc) run`