### PR TITLE
[FAT FS] Replace use of advance_path with seek_to function.

### DIFF
--- a/kernel/filesystem/exfat.hpp
+++ b/kernel/filesystem/exfat.hpp
@@ -92,7 +92,6 @@ public:
     void* list_directory(uint32_t cluster_count, uint32_t root_index);
     void* walk_directory(uint32_t cluster_count, uint32_t root_index, const char *seek, ef_entry_handler handler);
     void* read_cluster(uint32_t cluster_start, uint32_t cluster_size, uint32_t cluster_count, uint32_t root_index);
-    const char* advance_path(const char *path);
 
     exfat_mbs* mbs;
     void *fs_page;

--- a/kernel/filesystem/fat32.hpp
+++ b/kernel/filesystem/fat32.hpp
@@ -93,7 +93,6 @@ protected:
     sizedptr list_directory(uint32_t cluster_count, uint32_t root_index);
     sizedptr walk_directory(uint32_t cluster_count, uint32_t root_index, const char *seek, f32_entry_handler handler);
     sizedptr read_cluster(uint32_t cluster_start, uint32_t cluster_size, uint32_t cluster_count, uint32_t root_index);
-    const char* advance_path(const char *path);
 
     fat32_mbs* mbs = 0x0;
     void *fs_page = 0x0;


### PR DESCRIPTION
I saw there was a todo in the exfat and fat32 driver to replace a function called ``advance_path`` with the ``seek_to`` string function. I've removed the function in both drivers and replaced all uses of it with ``seek_to``. It works in the sense that when opening a window it is still able to find the example user program. However, more thorough testing should probably be done.