### PR TITLE
[Audio] Properly fix audio distortion

### DIFF
--- a/kernel/audio/virtio_audio_pci.cpp
+++ b/kernel/audio/virtio_audio_pci.cpp
@@ -201,7 +201,7 @@ bool VirtioAudioDriver::config_streams(uint32_t streams){
             out_dev = new OutputAudioDevice();
             out_dev->stream_id = stream;
             out_dev->channels = channels;
-            out_dev->packet_size = sizeof(virtio_snd_pcm_status) + sizeof(virtio_snd_pcm_xfer) + TOTAL_BUF_SIZE;
+            out_dev->packet_size = sizeof(virtio_snd_pcm_xfer) + TOTAL_BUF_SIZE;
             out_dev->buf_size = TOTAL_BUF_SIZE/SND_U32_BYTES;
             out_dev->header_size = sizeof(virtio_snd_pcm_xfer);
             out_dev->populate();


### PR DESCRIPTION
The remaining distortion present in audio output through virtio manifested as 2 extra random-valued samples at the end of each buffer.  This was due to an erroneous value for packet_size calculated when the output stream was configured.

Debugged and tested under Windows/WSL using Audacity to capture and inspect the audio output waveform.  It also sounds ok too!